### PR TITLE
fix(command and mongo db): spelling error in workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ odtp new execution-entry --digital-twin-id 65843acbe473dfffb95371d7 \
 --name execution-example \
 --components 65843bdf57da36bb8e8da182 \
 --versions 65843be057da36bb8e8da184 \
---worflow 0
+--workflow 0
 ```
 
 Info:
@@ -262,7 +262,7 @@ Finally the ODTP will be complemented with a components zoo that will include ex
 ## Technologies involved
 
 - Streamlit (UI)
-- Barfi (Worflow manager)
+- Barfi (Workflow manager)
 - MongoDB (Document Database)
 - S3 (Storage Sytem)
 - Docker (Container Technology)
@@ -361,7 +361,7 @@ executions = {
     "tags": ["tag1", "tag2"],
     "workflowSchema": {
         "workflowExecutor": "barfi",
-        "worflowExecutorVersion": "v2.0",
+        "workflowExecutorVersion": "v2.0",
         "components": [{"component": ObjectId(),
                         "version": ObjectId() }],  # Array of ObjectIds for components
         "WorkflowExecutorSchema": {}

--- a/bench/odtpDB.json
+++ b/bench/odtpDB.json
@@ -148,7 +148,7 @@
       ],
       "workflowSchema": {
         "workflowExecutor": "barfi",
-        "worflowExecutorVersion": "v2.0",
+        "workflowExecutorVersion": "v2.0",
         "components": [
           {
             "component": "65701dc519b363fe3dea879d",
@@ -175,7 +175,7 @@
       ],
       "workflowSchema": {
         "workflowExecutor": "barfi",
-        "worflowExecutorVersion": "v2.0",
+        "workflowExecutorVersion": "v2.0",
         "components": [
           {
             "component": "65701dc519b363fe3dea879d",

--- a/odtp/cli.py
+++ b/odtp/cli.py
@@ -209,7 +209,7 @@ def execution_entry(dt_id: str = typer.Option(
                 ),
                 workflow: str = typer.Option(
                 ...,
-                "--worflow",
+                "--workflow",
                 help="Specify the sequential order for the components, starting by 0, and separating values by commas"
                 )):
     
@@ -225,7 +225,7 @@ def execution_entry(dt_id: str = typer.Option(
     "tags": ["tag1", "tag2"],
     "workflowSchema": {
         "workflowExecutor": "odtpwf",
-        "worflowExecutorVersion": "0.2.0",
+        "workflowExecutorVersion": "0.2.0",
         "components": components_list,  # Array of ObjectIds for components
         "workflowExecutorSchema": [int(i) for i in workflow.split(",")]
     },

--- a/odtp/setup.py
+++ b/odtp/setup.py
@@ -184,7 +184,7 @@ class MockDataEmulator:
                 "tags": ["tag1", "tag2"],
                 "workflowSchema": {
                     "workflowExecutor": "barfi",
-                    "worflowExecutorVersion": "v2.0",
+                    "workflowExecutorVersion": "v2.0",
                     "components": [{"component": component_id,
                                     "version": version_id }],  # Array of ObjectIds for components. only one for testing
                     "WorkflowExecutorSchema": {}


### PR DESCRIPTION
change worflow to workflow in the db json structure as well as in the odtp command