### PR TITLE
fix(dotenv loading): load form file not from local environment

### DIFF
--- a/odtp/setup.py
+++ b/odtp/setup.py
@@ -5,15 +5,16 @@ from .db import MongoManager
 from .storage import s3Manager
 
 import logging
-import os
-from dotenv import load_dotenv
+from dotenv import dotenv_values
+
+
+config = dotenv_values(".env")
 
 
 class odtpDatabase:
     def __init__(self):
-        load_dotenv()
 
-        url = os.getenv("ODTP_MONGO_SERVER")
+        url = config["ODTP_MONGO_SERVER"]
         db_name = "odtp"
         dbManager = MongoManager(url, db_name)
 
@@ -58,11 +59,10 @@ class odtpDatabase:
 
 class s3Database:
     def __init__(self):
-        load_dotenv()
-        s3Server = os.getenv("ODTP_S3_SERVER")
-        bucketName = os.getenv("ODTP_BUCKET_NAME")
-        accessKey = os.getenv("ODTP_ACCESS_KEY")
-        secretKey = os.getenv("ODTP_SECRET_KEY")
+        s3Server = config["ODTP_S3_SERVER"]
+        bucketName = config["ODTP_BUCKET_NAME"]
+        accessKey = config["ODTP_ACCESS_KEY"]
+        secretKey = config["ODTP_SECRET_KEY"]
 
         storageManager = s3Manager(s3Server, bucketName, accessKey, secretKey)
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -9,8 +9,10 @@ import unittest
 import logging
 from odtp import db
 
-from dotenv import load_dotenv
-import os
+from dotenv import dotenv_values
+
+
+config = dotenv_values(".env")
 
 # # Set up logging
 # logging.basicConfig(level=logging.DEBUG)
@@ -38,9 +40,7 @@ class DBTests(unittest.TestCase):
         logging.basicConfig(level=logging.DEBUG)
         self.logger = logging.getLogger(__name__)
 
-        load_dotenv()
-
-        url = os.getenv("MONGOURL")
+        url = config["MONGOURL"]
         db_name = "odtp"
         dbManager = db.MongoManager(url, db_name)
 


### PR DESCRIPTION
replace `load_dotenv` by `dotenv_values` as the former function loads the local environment variables, but what we need is that the variables are loaded from the `.env` file