### PR TITLE
Flexible dashboard port

### DIFF
--- a/odtp/dashboard/main.py
+++ b/odtp/dashboard/main.py
@@ -1,4 +1,4 @@
-from nicegui import app, ui
+from nicegui import app, ui, native
 
 import odtp.dashboard.utils.ui_theme as ui_theme
 from odtp.dashboard.pages.page_about import content as about_page
@@ -54,4 +54,8 @@ def components():
 
 app.add_static_files("/static", "static")
 
-ui.run(title="ODTP", storage_secret="private key to secure the browser session cookie")
+ui.run(
+    title="ODTP", 
+    storage_secret="private key to secure the browser session cookie",
+    port=native.find_open_port()
+)


### PR DESCRIPTION
This PR allows to run the dashboard on any port: the dashboard will find by itself a free port to run on.