### PR TITLE
hotfixed recursive submodules missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Changelog
-
+- v.0.2.2: Bugs correction
+    - Including submodules when cloning file
 
 - v.0.2.1: Add docker compose for easy setup
     - add compose.yml: it can be build with `docker compose up`

--- a/odtp/run.py
+++ b/odtp/run.py
@@ -89,7 +89,8 @@ class DockerManager:
         logging.info(f"PREPARE: Downloading repository from {self.repo_url} to {self.repository_path}")
         subprocess.run(
             ["git", 
-             "clone", 
+             "clone",
+             "--recurse-submodules",
              self.repo_url, 
              os.path.join(self.project_folder, "repository")
             ]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='odtp',
-    version='0.2.1',
+    version='0.2.2',
     packages=find_packages(),
     description='Open Digital Twin Platform',
     long_description=open('README.md').read(),


### PR DESCRIPTION
Submodules weren't cloned as it was missing a flag in the git clone subconmand.

I propose this change to be consider 0.2.2 