### PR TITLE
Cli enhacement

### DIFF
--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -20,15 +20,24 @@ from typing import List
 
 
 @app.command()
-def prepare(
+def prepare(    
+    execution_name: str = typer.Option(
+        None, "--execution-name", help="Specify the name of the execution"
+    ),
     execution_id: str = typer.Option(
-        ..., "--execution-id", help="Specify the ID of the execution"
+        None, "--execution-id", help="Specify the ID of the execution"
     ),
     project_path: str = typer.Option(
         ..., "--project-path", help="Specify the path for the execution"
     ),
 ):  
     try:
+        if execution_id is None and execution_name is None:
+            raise typer.Exit("Please provide either --execution-name or --execution-id")
+
+        if execution_name:
+            execution_id = db.get_document_id_by_field_value("title", execution_name, "executions")
+
         execution = db.get_document_by_id(
             document_id=execution_id, 
             collection=db.collection_executions
@@ -46,8 +55,11 @@ def prepare(
 
 @app.command()
 def run(
+    execution_name: str = typer.Option(
+        None, "--execution-name", help="Specify the name of the execution"
+    ),
     execution_id: str = typer.Option(
-        ..., "--execution-id", help="Specify the ID of the execution"
+        None, "--execution-id", help="Specify the ID of the execution"
     ),
     project_path: str = typer.Option(
         ..., "--project-path", help="Specify the path for the execution"
@@ -57,6 +69,12 @@ def run(
     )] = None, 
 ): 
     try:
+        if execution_id is None and execution_name is None:
+            raise typer.Exit("Please provide either --execution-name or --execution-id")
+
+        if execution_name:
+            execution_id = db.get_document_id_by_field_value("title", execution_name, "executions")
+
         execution = db.get_document_by_id(
             document_id=execution_id, 
             collection=db.collection_executions
@@ -64,6 +82,7 @@ def run(
         step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])
         secrets = odtp_parse.parse_paramters_for_multiple_files(
             parameter_files=secrets_files, step_count=step_count)
+        print(secrets)
         flowManager = WorkflowManager(execution, project_path, secrets)
         flowManager.run_workflow()
     except Exception as e:

--- a/odtp/helpers/parse.py
+++ b/odtp/helpers/parse.py
@@ -3,6 +3,7 @@ import os
 
 from dotenv import dotenv_values
 
+import odtp.mongodb.db as db
 
 class OdtpParamterParsingException(Exception):
     pass
@@ -85,3 +86,24 @@ def parse_component_ports(ports):
 
 def parse_versions(component_versions):
     return component_versions.split(",")
+
+def parse_component_tags(component_tags):
+    steps_components_tags = component_tags.split(",")
+
+    versions_ids = []
+    for step_components_tag in steps_components_tags:
+        component_name = step_components_tag.split(":")[0]
+        component_version = step_components_tag.split(":")[1]
+
+        component_id = db.get_document_id_by_field_value("componentName", component_name, "components")
+        component_doc = db.get_document_by_id(component_id,"components")
+        for version in component_doc["versions"]:
+            version_doc = db.get_document_by_id(version, "versions")
+            if version_doc["component_version"] == component_version:
+                versions_ids.append(str(version_doc["_id"]))
+            else:
+                versions_ids.append(None)
+
+    print(versions_ids)
+    return versions_ids
+

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -124,6 +124,15 @@ def get_sub_collection_items(collection, sub_collection, item_id, ref_name):
         documents = mongodb_utils.get_list_from_cursor(cursor)
         return documents
 
+def get_document_id_by_field_value(field_path, field_value, collection):
+    with MongoClient(ODTP_MONGO_SERVER) as client:
+        db = client[ODTP_MONGO_DB]
+        document = db[collection].find_one({field_path: field_value}, {"_id": 1})
+        if document:
+            return str(document["_id"])
+        else:
+            return None
+
 
 def add_user(name, github, email):
     """add new user and return id"""


### PR DESCRIPTION
I added another experimental feature for the CLI. Now, the document IDs are not mandatory to run the executions. But we can use digital twins/executions names, and components tags (component:version i.e. odtp-eqasim:0.2.1 ) to build the pipeline in the CLI.

https://github.com/odtp-org/odtp/issues/93

This opens the door to creating bash scripts to run the whole execution, making it easier to perform full pipeline tests and share executions. Like this:

```
odtp new user-entry \
--name Ai-1234 \
--email ai@ai.com \
--github ai 

odtp new digital-twin-entry \
--user-email ai@ai.com  \
--name dt-example

odtp new execution-entry \
--name execution-eqasim-test \
--digital-twin-name dt-example \
--component-tags odtp-eqasim-dataloader:0.3.1,odtp-eqasim:0.4.2,odtp-eqasim-matsim:0.1.2,odtp-travel-data-dashboard:0.1.1 \
--parameter-files pa1,pa2,pa3,pa4 \
--ports ,,,8502:8501

odtp execution prepare --execution-name execution-eqasim-test --project-path corsica-dt

odtp execution run --execution-name execution-eqasim-test --secrets-files ,,,se4 --project-path corsica-dt
```

P.S. If you know a better name for this (component:version) construct, please let me know. I got inspired by how you can pull the images in docker