### PR TITLE
Improve dashboard components

### DIFF
--- a/odtp/dashboard/utils/helpers.py
+++ b/odtp/dashboard/utils/helpers.py
@@ -14,3 +14,15 @@ def pd_lists_to_counts(items_list):
     if not items_list:
         return 0
     return len([str(item) for item in items_list])
+
+
+def component_version_for_table(version):
+    component = version.get("component")
+    version_cleaned = {
+        "component": component.get("componentName"),
+        "repository": component.get("repoLink"),
+        "type": component.get("type"),
+        "version": version.get("component_version"),
+        "commit": version.get("commitHash")[:8]
+    }
+    return version_cleaned

--- a/odtp/dashboard/utils/validators.py
+++ b/odtp/dashboard/utils/validators.py
@@ -1,0 +1,39 @@
+import odtp.dashboard.utils.parse as parse
+import odtp.helpers.git as otdp_git
+import odtp.mongodb.utils as db_utils
+
+
+def validate_ports_input(value):
+    try:
+        ports = parse.parse_ports(value)
+        db_utils.check_component_ports(value)
+    except Exception as e:
+        return False
+    return True
+
+
+def validate_required_input(value):
+    if not value:
+        return False
+    return True
+
+
+def validate_github_url(value):
+    try:
+        otdp_git.check_commit_for_repo(value)
+        repo_info = otdp_git.get_github_repo_info(value)
+        print(repo_info)
+    except Exception as e:
+        return False
+    return True
+
+
+def validate_versions_git(value):
+    try:
+        repo_info = otdp_git.get_github_repo_info(value)
+        print(repo_info)
+        if not repo_info.get("tagged_versions"):
+            return False
+    except Exception as e:
+        return False
+    return True

--- a/odtp/helpers/git.py
+++ b/odtp/helpers/git.py
@@ -30,17 +30,38 @@ def make_github_api_call(url):
     return response
 
 
+def get_git_tagged_versions(github_api_tag_url):
+    if not github_api_tag_url:
+        return []
+    response = make_github_api_call(github_api_tag_url)
+    if response.status_code != 200:
+        return []
+    content = json.loads(response.content)
+    tagged_versions = []
+    for item in content:
+        item_dict = {
+            "name": item.get("name"),
+            "commit": item["commit"]["sha"],
+        }
+        tagged_versions.append(item_dict)
+    return tagged_versions
+
+
 def get_github_repo_info(repo_url):
     github_api_repo_url = f"{get_github_repo_url(repo_url)}"
     response = make_github_api_call(github_api_repo_url)
     if response.status_code == 200:
         content = json.loads(response.content)
+        github_api_tag_url = content.get("tags_url")
+        tagged_versions = get_git_tagged_versions(github_api_tag_url)
         repo_info = {
             "html_url": content.get("html_url"),
             "description": content.get("description"),
             "visibility": content.get("visibility"),
             "license": content.get("license", {}).get("name"),
             "name": content.get("name"),
+            "tag_url": github_api_tag_url,
+            "tagged_versions": tagged_versions,
         }
         return repo_info
 


### PR DESCRIPTION
This PR improves the management of Components in the dashboard:

- only tagged versions of components can be added: the commit is then directly taken from the tagged version on github
- it is visibly distinguished between info coming from github and info coming from odtp
- users are offered to add all versions of a component that are new on github, but not yet available on odtp.
- the workflow to add new versions for a component had some bugs that have now been adressed
- all forms have now validation, to make sure components and versions are all added correctly
