### PR TITLE
Component version instead of commits

### DIFF
--- a/odtp/cli/new.py
+++ b/odtp/cli/new.py
@@ -8,6 +8,7 @@ import odtp.mongodb.db as db
 import odtp.helpers.parse as odtp_parse
 import odtp.mongodb.utils as db_utils
 import odtp.helpers.utils as odtp_utils
+import odtp.helpers.git as odtp_git
 
 
 ## Adding listing so we can have multiple flags
@@ -36,31 +37,23 @@ def odtp_component_entry(
         help="Specify the repository"
     )],
     component_version: Annotated[str, typer.Option(
-        help="Specify the component version"
-    )],    
-    odtp_version: Annotated[str, typer.Option(
-        help="Specify the version of odtp"
-    )] = None,
-    commit: Annotated[str, typer.Option(
-        help="""You may specify the commit of the repository. If not provided 
-        the latest commit will be fetched"""
-    )] = None,
+        help="Specify the tagged component version. It needs to be available on the github repo"
+    )],
     type: Annotated[str, typer.Option(
         help="""You may specify the type of the component as either 'ephemeral or persistent'"""
     )] = db_utils.COMPONENT_TYPE_EPHERMAL,    
     ports: Annotated[str, typer.Option(
         help="Specify ports seperated by a comma i.e. 8501,8201"
     )] = None,
-):  
+):
     try:
         ports = odtp_parse.parse_component_ports(ports)
+        repo_info = odtp_git.get_github_repo_info(repository)
         component_id, version_id = \
             db.add_component_version(
                 component_name=name,
-                repository=repository,
-                odtp_version=odtp_version,
+                repo_info=repo_info,
                 component_version=component_version,
-                commit_hash=commit,
                 type=type,
                 ports=ports,
             )

--- a/odtp/dashboard/main.py
+++ b/odtp/dashboard/main.py
@@ -52,5 +52,5 @@ ui.run(
     title="ODTP", 
     storage_secret="private key to secure the browser session cookie", 
     port=ODTP_DASHBOARD_PORT,
-    reload=ODTP_DASHBOARD_RELOAD
+    reload=True,
 )

--- a/odtp/dashboard/main.py
+++ b/odtp/dashboard/main.py
@@ -52,5 +52,5 @@ ui.run(
     title="ODTP", 
     storage_secret="private key to secure the browser session cookie", 
     port=ODTP_DASHBOARD_PORT,
-    reload=True,
+    reload=ODTP_DASHBOARD_RELOAD,
 )

--- a/odtp/dashboard/utils/storage.py
+++ b/odtp/dashboard/utils/storage.py
@@ -151,10 +151,12 @@ def storage_update_add_execution_step(
 
 
 def storage_update_add_component(repo_link):
+    """the repo link that gets stored for the component is taken from the
+    github api, so that repos are not stored double"""
     latest_commit = odtp_git.check_commit_for_repo(repo_link)
     repo_info = odtp_git.get_github_repo_info(repo_link)
     add_component = {
-        "repo_link": repo_link,
+        "repo_link": repo_info.get("html_url"),
         "latest_commit": latest_commit,
         "repo_info": repo_info,
     }

--- a/odtp/dashboard/utils/validators.py
+++ b/odtp/dashboard/utils/validators.py
@@ -1,15 +1,17 @@
+import re
 import odtp.dashboard.utils.parse as parse
 import odtp.helpers.git as otdp_git
 import odtp.mongodb.utils as db_utils
 
 
 def validate_ports_input(value):
+    if not value:
+        return True
     try:
-        ports = parse.parse_ports(value)
-        db_utils.check_component_ports(value)
+        if re.match(db_utils.PORT_PATTERN, value):
+            return True
     except Exception as e:
         return False
-    return True
 
 
 def validate_required_input(value):
@@ -20,20 +22,9 @@ def validate_required_input(value):
 
 def validate_github_url(value):
     try:
-        otdp_git.check_commit_for_repo(value)
         repo_info = otdp_git.get_github_repo_info(value)
-        print(repo_info)
-    except Exception as e:
-        return False
-    return True
-
-
-def validate_versions_git(value):
-    try:
-        repo_info = otdp_git.get_github_repo_info(value)
-        print(repo_info)
         if not repo_info.get("tagged_versions"):
-            return False
+            raise otdp_git.OdtpGithubException(f"repo {value} has no versions")
     except Exception as e:
-        return False
+        raise(e)
     return True

--- a/odtp/helpers/git.py
+++ b/odtp/helpers/git.py
@@ -61,6 +61,7 @@ def get_github_repo_info(repo_url):
             "license": content.get("license", {}).get("name"),
             "name": content.get("name"),
             "tag_url": github_api_tag_url,
+            "commits_url": content.get("commits_url"),
             "tagged_versions": tagged_versions,
         }
         return repo_info
@@ -79,3 +80,14 @@ def check_commit_for_repo(repo_url, commit_hash=None):
             if commit_hash in commits:
                 return commit_hash
     raise OdtpGithubException(f"Github repo {repo_url} has no commit {commit_hash}")
+
+
+def get_commit_of_component_version(repo_info, component_version):
+    tagged_versions = repo_info.get("tagged_versions")
+    if not tagged_versions:
+        raise OdtpGithubException(f"Github repo {repo_info.get('url')} has no versions.")
+    version_commit = [version["commit"] for version in tagged_versions
+                      if version["name"] == component_version]
+    if not version_commit:
+        raise OdtpGithubException(f"Github repo {repo_info.get('url')} has no version {component_version}")
+    return version_commit[0]

--- a/odtp/helpers/settings.py
+++ b/odtp/helpers/settings.py
@@ -5,12 +5,20 @@ from dotenv import load_dotenv
 load_dotenv()
 logging.info("environment variables loaded")
 
-ODTP_MONGO_SERVER = os.getenv("ODTP_MONGO_SERVER")
-GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
-ODTP_MONGO_DB = os.getenv("ODTP_MONGO_DB")
-ODTP_S3_SERVER = os.getenv("ODTP_S3_SERVER")
-ODTP_BUCKET_NAME = os.getenv("ODTP_BUCKET_NAME")
-ODTP_ACCESS_KEY = os.getenv("ODTP_ACCESS_KEY")
-ODTP_SECRET_KEY = os.getenv("ODTP_SECRET_KEY")
-ODTP_DASHBOARD_PORT = int(os.getenv("ODTP_DASHBOARD_PORT"))
-ODTP_DASHBOARD_RELOAD = bool(os.getenv("ODTP_DASHBOARD_RELOAD"))
+
+class OdtpSettingsException(Exception):
+    pass
+
+
+try:
+    ODTP_MONGO_SERVER = os.getenv("ODTP_MONGO_SERVER")
+    GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
+    ODTP_MONGO_DB = os.getenv("ODTP_MONGO_DB")
+    ODTP_S3_SERVER = os.getenv("ODTP_S3_SERVER")
+    ODTP_BUCKET_NAME = os.getenv("ODTP_BUCKET_NAME")
+    ODTP_ACCESS_KEY = os.getenv("ODTP_ACCESS_KEY")
+    ODTP_SECRET_KEY = os.getenv("ODTP_SECRET_KEY")
+    ODTP_DASHBOARD_PORT = int(os.getenv("ODTP_DASHBOARD_PORT"))
+    ODTP_DASHBOARD_RELOAD = eval(os.getenv("ODTP_DASHBOARD_RELOAD"))
+except Exception as e:
+    raise OdtpSettingsException(f"Configuration of ODTP raised an exception {e}")


### PR DESCRIPTION
This PR makes the following changes:

- **component versions** in ODTP should correspond to the tags on their github repos. Therefore only version names are taken, where the tags can be found on github.
- **repo url**: Additionally the url is taken from github for a component. This avoids that the component will be registered multiple time
- `datetime.utcnow() is deprecated` and is been replaced by `datetime.now(timezone.utc)`
- Fix settings with boolean values: `eval` must be used instead of `bool` and try except block is added for making settings errors better understandable