### PR TITLE
Fix cli new execution

### DIFF
--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -80,7 +80,7 @@ def run(
             collection=db.collection_executions
         )
         step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])
-        secrets = odtp_parse.parse_paramters_for_multiple_files(
+        secrets = odtp_parse.parse_parameters_for_multiple_files(
             parameter_files=secrets_files, step_count=step_count)
         print(secrets)
         flowManager = WorkflowManager(execution, project_path, secrets)

--- a/odtp/cli/new.py
+++ b/odtp/cli/new.py
@@ -121,7 +121,7 @@ def execution_entry(
         step_count = len(versions)
         ports = odtp_parse.parse_port_mappings_for_multiple_components(
             ports=ports, step_count=step_count)
-        parameters = odtp_parse.parse_paramters_for_multiple_files(
+        parameters = odtp_parse.parse_parameters_for_multiple_files(
             parameter_files=parameter_files, step_count=step_count)
         execution_id, step_ids = db.add_execution(
             dt_id=dt_id,

--- a/odtp/helpers/parse.py
+++ b/odtp/helpers/parse.py
@@ -5,41 +5,41 @@ from dotenv import dotenv_values
 
 import odtp.mongodb.db as db
 
-class OdtpParamterParsingException(Exception):
+class OdtpParameterParsingException(Exception):
     pass
 
 
-def parse_paramters_for_one_file(parameter_file):
+def parse_parameters_for_one_file(parameter_file):
     if not parameter_file:
         return {}
     if not os.path.isfile(parameter_file):
-        raise OdtpParamterParsingException(
+        raise OdtpParameterParsingException(
             f"Parsing of file {parameter_file} failed: file path not valid"
         )
     try:
         parameters = dotenv_values(parameter_file)
         json.dumps(parameters)
     except Exception as e:
-        raise OdtpParamterParsingException(f"Parsing of file {parameter_file} failed")
+        raise OdtpParameterParsingException(f"Parsing of file {parameter_file} failed")
     else:
         return parameters
 
 
-def parse_paramters_for_multiple_files(parameter_files, step_count):
+def parse_parameters_for_multiple_files(parameter_files, step_count):
     if not parameter_files:
         return [None for i in range(step_count)]
     try:
         parameters_output = []
         parameters_per_step = parameter_files.split(",")
         for parameter_file in parameters_per_step:
-            parameters = parse_paramters_for_one_file(parameter_file)
+            parameters = parse_parameters_for_one_file(parameter_file)
             parameters_output.append(parameters)
         if not len(parameters_output) == step_count:
-            raise OdtpParamterParsingException(
+            raise OdtpParameterParsingException(
                 "Invalid ports specification: not as many ports definition  as steps: {ports}"
             )
     except Exception as e:
-        raise OdtpParamterParsingException(f"Parsing of file {parameter_file} failed")
+        raise OdtpParameterParsingException(f"Parsing of file {parameter_file} failed")
     else:
         return parameters_output
 
@@ -53,11 +53,11 @@ def parse_port_mappings_for_multiple_components(ports, step_count):
         for ports in ports_per_step:
             ports_output.append(parse_port_mappings_for_one_component(ports))
         if not len(ports_output) == step_count:
-            raise OdtpParamterParsingException(
+            raise OdtpParameterParsingException(
                 "Invalid ports specification: not as many ports definition  as steps: {ports}"
             )
     except Exception as e:
-        raise OdtpParamterParsingException(f"Parsing of ports {ports} failed")
+        raise OdtpParameterParsingException(f"Parsing of ports {ports} failed")
     else:
         return ports_output
 
@@ -68,7 +68,7 @@ def parse_port_mappings_for_one_component(ports):
     try:
         ports = ports.split("+")
     except Exception as e:
-        raise OdtpParamterParsingException(f"Parsing of ports {ports} failed")
+        raise OdtpParameterParsingException(f"Parsing of ports {ports} failed")
     else:
         return ports
 
@@ -79,7 +79,7 @@ def parse_component_ports(ports):
     try:
         ports = ports.split(",")
     except Exception as e:
-        raise OdtpParamterParsingException(f"Parsing of ports {ports} failed")
+        raise OdtpParameterParsingException(f"Parsing of ports {ports} failed")
     else:
         return ports
 
@@ -88,22 +88,23 @@ def parse_versions(component_versions):
     return component_versions.split(",")
 
 def parse_component_tags(component_tags):
+    version_ids = []
     steps_components_tags = component_tags.split(",")
-
-    versions_ids = []
     for step_components_tag in steps_components_tags:
         component_name = step_components_tag.split(":")[0]
         component_version = step_components_tag.split(":")[1]
-
-        component_id = db.get_document_id_by_field_value("componentName", component_name, "components")
-        component_doc = db.get_document_by_id(component_id,"components")
-        for version in component_doc["versions"]:
-            version_doc = db.get_document_by_id(version, "versions")
-            if version_doc["component_version"] == component_version:
-                versions_ids.append(str(version_doc["_id"]))
-            else:
-                versions_ids.append(None)
-
-    print(versions_ids)
-    return versions_ids
-
+        version_documents = db.get_component_version(
+            component_name=component_name,
+            version_tag=component_version
+        )
+        if len(version_documents) > 1:
+            raise OdtpParameterParsingException(
+                f"Found more than one component version for {component_version}"
+            )
+        elif len(version_documents) == 0:
+            raise OdtpParameterParsingException(
+                f"Component version {component_version} not found"
+            )
+        version_id = str(version_documents[0]["_id"])
+        version_ids.append(version_id)
+    return version_ids

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -77,6 +77,17 @@ def get_document_by_ids_in_collection(document_ids, collection):
     return documents
 
 
+def get_component_version(component_name, version_tag):
+    with MongoClient(ODTP_MONGO_SERVER) as client:
+        db = client[ODTP_MONGO_DB]
+        collection = collection_versions
+        cursor = db[collection].find(
+            {"component_version": version_tag, "component.componentName": component_name}
+        )
+        documents = mongodb_utils.get_list_from_cursor(cursor)
+    return documents
+
+
 def check_document_ids_in_collection(document_ids, collection):
     with MongoClient(ODTP_MONGO_SERVER) as client:
         db = client[ODTP_MONGO_DB]


### PR DESCRIPTION
This PR fixes a bug for the cli command `odtp new execution-entry`:

The parameter ` --component-tags` was not parsed correctly:

- a new mongodb function was added to find the version_ids from the component-tags
- in some function names the spelling was corrected.