### PR TITLE
fix(dependencies): Removing pyarrow and freezing numpy to <2 to avoid…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,28 +44,15 @@ RUN wget https://www.python.org/ftp/python/3.11.0/Python-3.11.0.tar.xz \
 # Remove the Python source and tarball to reduce image size
 RUN rm -rf Python-3.11.0.tar.xz Python-3.11.0
 
-# Install Python and Poetry
-RUN python3 -m ensurepip && \
-    pip3 install --upgrade pip setuptools
-
-# Install PyArrow in ALPINE
-## https://stackoverflow.com/questions/49059779/how-to-install-pyarrow-on-an-alpine-docker-image/53116069#53116069
-## https://discuss.streamlit.io/t/anyone-tried-to-install-streamlit-in-alpine-docker-image/56893
-RUN apk update && apk add \
-    apache-arrow-dev \
-    py3-pyarrow \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN pip3 install --upgrade pip && \
-    pip3 install --break-system-packages numpy pyarrow==12.0.0
-
-# Add your application's source code
+# Adding odtp source code and installing it.
 COPY . /app
 WORKDIR /app
 RUN pip3 install --break-system-packages $PIP_INSTALL_ARGS .
 
+# Symbolic link to ODTP_PATH to facilitate debugging
+RUN ln -s $ODTP_PATH /ODTP_PATH
+
 # Symbolic link between python and python3
-RUN rm /usr/bin/python
 RUN ln -s /usr/local/bin/python3 /usr/bin/python
 
 # Entry point in a sh session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "odtp"
-version = "0.3.0"
+version = "0.3.1"
 description = "A tool to deploy and manage open digital twins"
 authors = ["caviri <carlosvivarrios@gmail.com>", "sabinem <sabine.maennel@sdsc.ethz.ch>"]
 license = "AGPL 3.0"
@@ -8,19 +8,16 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
+requests = "2.32.3"
 pydantic = "2.5.2"
+numpy = "1.26.4"
 typer = "0.9.0"
 pymongo = ">=4.6.3"
 python-dotenv = "^1.0.0"
 boto3 = "^1.33.13"
-barfi = "^0.7.0"
-streamlit = "^1.29.0"
-st-pages = "^0.4.5"
-streamlit-card = "^1.0.0"
-pygwalker = "^0.3.17"
-streamlit-aggrid = "^0.3.4.post3"
 nicegui = "1.4.24"
 directory-tree = "^0.0.4"
+
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"


### PR DESCRIPTION
… errors and warnings

I removed unused dependencies and simplified the Dockerfile. I propose this as a hot-fix for the main as the CLI cannot be executed with the Numpy-related error. 