### PR TITLE
fix(S3 Initiation): Fix for S3 initial setup

### DIFF
--- a/odtp/cli/s3.py
+++ b/odtp/cli/s3.py
@@ -31,7 +31,7 @@ def download(
 def check():  
     try:
         s3 = s3Manager()
-        bucket = s3.test_connection()
+        s3.test_connection()
         print("S3 is connected. Bucket is ready to use")
     except Exception as e:
         log.exception(f"S3 connection could not be established: an Exception {e} occurred")

--- a/odtp/cli/setup.py
+++ b/odtp/cli/setup.py
@@ -2,22 +2,25 @@
 This scripts contains odtp subcommands for 'setup'
 """
 import typer
-
+import logging
 from odtp.storage import s3Manager
 import odtp.mongodb.db as db
 
 app = typer.Typer()
 
+log = logging.getLogger(__name__)
 
 @app.command()
 def initiate():
     db.init_collections()
 
     odtpS3 = s3Manager()
-    bucketAvailable = odtpS3.test_connection()
-    if not bucketAvailable:
-        print("S3 bucket not found. Please create the bucket on minio folder or use the dashboard.")
-        return
+    try:
+        bucketAvailable = odtpS3.test_connection()
+    except Exception as e:
+        logging.error("S3 bucket not found. Please create the bucket on minio folder or use the dashboard.")
+        log.exception(e)
+
 
     odtpS3.createFolderStructure(["odtp"])
     odtpS3.close()

--- a/odtp/cli/setup.py
+++ b/odtp/cli/setup.py
@@ -14,7 +14,12 @@ def initiate():
     db.init_collections()
 
     odtpS3 = s3Manager()
-    odtpS3.create_folders(["odtp"])
+    bucketAvailable = odtpS3.test_connection()
+    if not bucketAvailable:
+        print("S3 bucket not found. Please create the bucket on minio folder or use the dashboard.")
+        return
+
+    odtpS3.createFolderStructure(["odtp"])
     odtpS3.close()
 
     print("ODTP DB/S3 data generated")

--- a/odtp/storage.py
+++ b/odtp/storage.py
@@ -16,12 +16,7 @@ class s3Manager:
         self.bucketName = settings.ODTP_BUCKET_NAME
 
     def test_connection(self):
-        try:
-            bucket = self.s3.head_bucket(Bucket=self.bucketName)
-
-            return bucket
-        except:
-            return False
+        bucket = self.s3.head_bucket(Bucket=self.bucketName)
 
     # Method to close the client connection
     def closeConnection(self):

--- a/odtp/storage.py
+++ b/odtp/storage.py
@@ -16,7 +16,7 @@ class s3Manager:
         self.bucketName = settings.ODTP_BUCKET_NAME
 
     def test_connection(self):
-        bucket = self.s3.head_bucket(Bucket=self.bucketName)
+        self.s3.head_bucket(Bucket=self.bucketName)
 
     # Method to close the client connection
     def closeConnection(self):

--- a/odtp/storage.py
+++ b/odtp/storage.py
@@ -16,8 +16,12 @@ class s3Manager:
         self.bucketName = settings.ODTP_BUCKET_NAME
 
     def test_connection(self):
-        bucket = self.s3.head_bucket(Bucket=self.bucketName)
-        return bucket    
+        try:
+            bucket = self.s3.head_bucket(Bucket=self.bucketName)
+
+            return bucket
+        except:
+            return False
 
     # Method to close the client connection
     def closeConnection(self):


### PR DESCRIPTION
When running the S3 setup, it gave an error due to a redundant method for creating folders. I changed the previous method, `createFolderStructure,` and provided some previous checking for bucket availability.  