### PR TITLE
Initial Folder structure (develop <- initial-folder-structure)

### DIFF
--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -47,7 +47,7 @@ def prepare(
 
         if not project_path:
             #Inferring project path from naming convention
-            dt_doc, user_doc, _ = get_execution_path_docs(db, execution_id)
+            dt_doc, user_doc, _ = db.get_execution_path_docs(db, execution_id)
 
             execution_path = odtp_filesystem.generate_execution_path(user_doc, dt_doc, execution_doc)
             project_path = execution_path
@@ -92,7 +92,7 @@ def run(
 
         if not project_path:
             #Inferring project path from naming convention
-            user_doc, dt_doc, _ = get_execution_path_docs(db, execution_id)
+            user_doc, dt_doc, _ = db.get_execution_path_docs(db, execution_id)
 
             execution_path = odtp_filesystem.generate_execution_path(user_doc, dt_doc, execution_doc)
             project_path = execution_path

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -47,8 +47,7 @@ def prepare(
 
         if not project_path:
             #Inferring project path from naming convention
-            dt_doc, user_doc, _ = db.get_execution_path_docs(db, execution_id)
-
+            user_doc, dt_doc, _ = db.get_execution_path_docs(db, execution_id)
             execution_path = odtp_filesystem.generate_execution_path(user_doc, dt_doc, execution_doc)
             project_path = execution_path
 

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -38,7 +38,7 @@ def prepare(
             raise typer.Exit("Please provide either --execution-name or --execution-id")
 
         if execution_name:
-            execution_id = db.get_document_id_by_field_value("title", execution_name, "executions")
+            execution_id = db.get_document_id_by_field_value("title", execution_name, db.collection_executions)
 
         execution_doc = db.get_document_by_id(
             document_id=execution_id, 
@@ -83,7 +83,7 @@ def run(
             raise typer.Exit("Please provide either --execution-name or --execution-id")
 
         if execution_name:
-            execution_id = db.get_document_id_by_field_value("title", execution_name, "executions")
+            execution_id = db.get_document_id_by_field_value("title", execution_name, db.collection_executions)
 
         execution_doc = db.get_document_by_id(
             document_id=execution_id, 

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -30,7 +30,7 @@ def prepare(
         None, "--execution-id", help="Specify the ID of the execution"
     ),
     project_path: str = typer.Option(
-        ..., "--project-path", help="Specify the path for the execution"
+        None, "--project-path", help="Specify the path for the execution"
     ),
 ):  
     try:
@@ -72,7 +72,7 @@ def run(
         None, "--execution-id", help="Specify the ID of the execution"
     ),
     project_path: str = typer.Option(
-        ..., "--project-path", help="Specify the path for the execution"
+        None, "--project-path", help="Specify the path for the execution"
     ),
     secrets_files: Annotated[str, typer.Option(
         help="List the files containing the secrets by step separated by commas"

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -12,6 +12,7 @@ from odtp.workflow import WorkflowManager
 from directory_tree import display_tree
 import odtp.helpers.environment as odtp_env
 import odtp.helpers.settings as config
+import odtp.helpers.filesystem as odtp_filesystem
 import os
 
 from nicegui import ui
@@ -51,17 +52,13 @@ def prepare(
                 document_id=dt_id, 
                 collection=db.collection_digital_twins
             )
-            dt_name = dt_doc["name"]
             user_id = dt_doc["userRef"]
             user_doc = db.get_document_by_id(
                 document_id=user_id, 
                 collection=db.collection_users
             )
-            user_name = user_doc["name"]
 
-            user_path = os.path.join(config.ODTP_PATH, user_name)
-            dt_path = os.path.join(user_path, dt_name)
-            execution_path = os.path.join(dt_path, execution_name)
+            execution_path = odtp_filesystem.generate_execution_path(user_doc, dt_doc, execution)
             project_path = execution_path
 
         step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])
@@ -109,17 +106,13 @@ def run(
                 document_id=dt_id, 
                 collection=db.collection_digital_twins
             )
-            dt_name = dt_doc["name"]
             user_id = dt_doc["userRef"]
             user_doc = db.get_document_by_id(
                 document_id=user_id, 
                 collection=db.collection_users
             )
-            user_name = user_doc["name"]
 
-            user_path = os.path.join(config.ODTP_PATH, user_name)
-            dt_path = os.path.join(user_path, dt_name)
-            execution_path = os.path.join(dt_path, execution_name)
+            execution_path = odtp_filesystem.generate_execution_path(user_doc, dt_doc, execution)
             project_path = execution_path
 
         step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -4,17 +4,20 @@ This scripts contains odtp subcommands for 'execution'
 import sys
 import typer
 from typing_extensions import Annotated
-
+## Adding listing so we can have multiple flags
+from typing import List
 import odtp.mongodb.db as db
 import odtp.helpers.parse as odtp_parse
 from odtp.workflow import WorkflowManager
 from directory_tree import display_tree
+import odtp.helpers.environment as odtp_env
+import odtp.helpers.settings as config
 import os
+
+from nicegui import ui
 
 app = typer.Typer()
 
-## Adding listing so we can have multiple flags
-from typing import List
 
 
 @app.command()
@@ -40,6 +43,27 @@ def prepare(
             document_id=execution_id, 
             collection=db.collection_executions
         )
+
+        if not project_path:
+            #Inferring project path from naming convention
+            dt_id = execution["digitalTwinRef"]
+            dt_doc = db.get_document_by_id(
+                document_id=dt_id, 
+                collection=db.collection_digital_twins
+            )
+            dt_name = dt_doc["name"]
+            user_id = dt_doc["userRef"]
+            user_doc = db.get_document_by_id(
+                document_id=user_id, 
+                collection=db.collection_users
+            )
+            user_name = user_doc["name"]
+
+            user_path = os.path.join(config.ODTP_PATH, user_name)
+            dt_path = os.path.join(user_path, dt_name)
+            execution_path = os.path.join(dt_path, execution_name)
+            project_path = execution_path
+
         step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])
         secrets = [None for i in range(step_count)]
         flowManager = WorkflowManager(execution, project_path, secrets)
@@ -77,6 +101,27 @@ def run(
             document_id=execution_id, 
             collection=db.collection_executions
         )
+
+        if not project_path:
+            #Inferring project path from naming convention
+            dt_id = execution["digitalTwinRef"]
+            dt_doc = db.get_document_by_id(
+                document_id=dt_id, 
+                collection=db.collection_digital_twins
+            )
+            dt_name = dt_doc["name"]
+            user_id = dt_doc["userRef"]
+            user_doc = db.get_document_by_id(
+                document_id=user_id, 
+                collection=db.collection_users
+            )
+            user_name = user_doc["name"]
+
+            user_path = os.path.join(config.ODTP_PATH, user_name)
+            dt_path = os.path.join(user_path, dt_name)
+            execution_path = os.path.join(dt_path, execution_name)
+            project_path = execution_path
+
         step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])
         secrets = odtp_parse.parse_parameters_for_multiple_files(
             parameter_files=secrets_files, step_count=step_count)

--- a/odtp/cli/new.py
+++ b/odtp/cli/new.py
@@ -30,7 +30,7 @@ def user_entry(
     """Add new user in the MongoDB"""
     user_id = db.add_user(name=name, github=github, email=email)
     
-    user_doc = get_user_path_doc(db, user_id)
+    user_doc = db.get_user_path_doc(db, user_id)
     
     try:
         user_path = odtp_filesystem.generate_user_path(user_doc)
@@ -91,11 +91,11 @@ def digital_twin_entry(
         raise typer.Exit("Please provide either --user-id or --user-email")
 
     if user_email:
-        user_id = db.get_document_id_by_field_value("user_email", user_email, "users")
+        user_id = db.get_document_id_by_field_value("email", user_email, db.collection_users)
     
     dt_id = db.add_digital_twin(userRef=user_id, name=name)
 
-    user_doc, dt_doc = get_digital_twin_path_docs(db, dt_id)
+    user_doc, dt_doc = db.get_digital_twin_path_docs(db, dt_id)
     dt_path = odtp_filesystem.generate_digital_twin_path(user_doc, dt_doc)
 
     try:
@@ -156,7 +156,7 @@ def execution_entry(
         )
 
 
-        user_doc, dt_doc, execution_doc = get_execution_path_docs(db, execution_id)
+        user_doc, dt_doc, execution_doc = db.get_execution_path_docs(db, execution_id)
         execution_path = odtp_filesystem.generate_execution_path(user_doc, dt_doc, execution_doc)
 
 

--- a/odtp/cli/setup.py
+++ b/odtp/cli/setup.py
@@ -5,7 +5,7 @@ import typer
 import logging
 from odtp.storage import s3Manager
 import odtp.mongodb.db as db
-from odtp.helpers.filesystem import create_main_folders, delete_main_folders
+from odtp.helpers.filesystem import create_folders, delete_folders
 
 app = typer.Typer()
 
@@ -26,7 +26,7 @@ def initiate():
     odtpS3.createFolderStructure(["odtp"])
     odtpS3.close()
 
-    create_main_folders()
+    create_folders(["users"])
 
     print("ODTP DB/S3 data generated")
 
@@ -38,7 +38,7 @@ def delete():
     odtpS3 = s3Manager()
     odtpS3.deleteAll()
 
-    delete_main_folders()
+    delete_folders(["odtp"])
 
     print("All deleted")
 

--- a/odtp/cli/setup.py
+++ b/odtp/cli/setup.py
@@ -5,7 +5,7 @@ import typer
 import logging
 from odtp.storage import s3Manager
 import odtp.mongodb.db as db
-from odtp.helpers.filesystem import create_folders, delete_folders
+from odtp.helpers.filesystem import create_main_folders, delete_main_folders
 
 app = typer.Typer()
 
@@ -17,16 +17,16 @@ def initiate():
 
     odtpS3 = s3Manager()
     try:
-        bucketAvailable = odtpS3.test_connection()
+        odtpS3.test_connection()
     except Exception as e:
-        logging.error("S3 bucket not found. Please create the bucket on minio folder or use the dashboard.")
+        log.error("S3 bucket not found. Please create the bucket on minio folder or use the dashboard.")
         log.exception(e)
 
 
     odtpS3.createFolderStructure(["odtp"])
     odtpS3.close()
 
-    create_folders()
+    create_main_folders()
 
     print("ODTP DB/S3 data generated")
 
@@ -38,7 +38,7 @@ def delete():
     odtpS3 = s3Manager()
     odtpS3.deleteAll()
 
-    delete_folders()
+    delete_main_folders()
 
     print("All deleted")
 

--- a/odtp/cli/setup.py
+++ b/odtp/cli/setup.py
@@ -5,7 +5,7 @@ import typer
 import logging
 from odtp.storage import s3Manager
 import odtp.mongodb.db as db
-from odtp.helpers.filesystem import create_folders, delete_folders
+import odtp.helpers.filesystem as odtp_filesystem
 
 app = typer.Typer()
 
@@ -26,7 +26,7 @@ def initiate():
     odtpS3.createFolderStructure(["odtp"])
     odtpS3.close()
 
-    create_folders(["users"])
+    odtp_filesystem.create_folders(["users"])
 
     print("ODTP DB/S3 data generated")
 
@@ -38,7 +38,7 @@ def delete():
     odtpS3 = s3Manager()
     odtpS3.deleteAll()
 
-    delete_folders(["odtp"])
+    odtp_filesystem.delete_folders(["odtp"])
 
     print("All deleted")
 

--- a/odtp/cli/setup.py
+++ b/odtp/cli/setup.py
@@ -5,6 +5,7 @@ import typer
 import logging
 from odtp.storage import s3Manager
 import odtp.mongodb.db as db
+from odtp.helpers.filesystem import create_folders, delete_folders
 
 app = typer.Typer()
 
@@ -25,6 +26,8 @@ def initiate():
     odtpS3.createFolderStructure(["odtp"])
     odtpS3.close()
 
+    create_folders()
+
     print("ODTP DB/S3 data generated")
 
 
@@ -34,6 +37,8 @@ def delete():
 
     odtpS3 = s3Manager()
     odtpS3.deleteAll()
+
+    delete_folders()
 
     print("All deleted")
 

--- a/odtp/helpers/filesystem.py
+++ b/odtp/helpers/filesystem.py
@@ -23,3 +23,18 @@ def delete_folders(relative_paths, odtp_path = config.ODTP_PATH):
 
         log.debug(f"Folder created: {full_path}")
 
+
+def generate_user_path(user_doc):
+    return user_doc["name"]
+
+def generate_digital_twin_path(user_doc, digital_twin_doc):
+    user_name = user_doc["name"]
+    dt_name = digital_twin_doc["name"]
+    dt_path = os.path.join(user_name, dt_name)
+    return dt_path
+
+def generate_execution_path(user_doc, digital_twin_doc, execution_doc):
+    execution_name = execution_doc["name"]
+    dt_path = generate_digital_twin_path(user_doc, digital_twin_doc)
+    execution_path = os.path.join(dt_path, execution_name)
+    return execution_path

--- a/odtp/helpers/filesystem.py
+++ b/odtp/helpers/filesystem.py
@@ -4,16 +4,22 @@ import shutil
 import os
 import odtp.helpers.settings as config
 
-def create_main_folders(odtp_path = config.ODTP_PATH):
-    users_folder = os.path.join(odtp_path, 'users')
+log = logging.getLogger(__name__)
 
-    os.makedirs(users_folder, exist_ok=True)
+def create_folders(relative_paths, odtp_path = config.ODTP_PATH, exist_ok=False):
+    for relative_path in relative_paths:
+        full_path = os.path.join(odtp_path, relative_path)
 
-    logging.info("Folders created: %s, %s", users_folder)
+        os.makedirs(full_path, exist_ok=exist_ok)
 
-def delete_main_folders(odtp_path = config.ODTP_PATH):
-    users_folder = os.path.join(odtp_path, 'users')
+        log.debug(f"Folder created: {full_path}")
 
-    shutil.rmtree(users_folder)
 
-    logging.info("Folders deleted: %s, %s", users_folder)
+def delete_folders(relative_paths, odtp_path = config.ODTP_PATH):
+    for relative_path in relative_paths:
+        full_path = os.path.join(odtp_path, relative_path)
+
+        shutil.rmtree(full_path)
+
+        log.debug(f"Folder created: {full_path}")
+

--- a/odtp/helpers/filesystem.py
+++ b/odtp/helpers/filesystem.py
@@ -25,16 +25,16 @@ def delete_folders(relative_paths, odtp_path = config.ODTP_PATH):
 
 
 def generate_user_path(user_doc):
-    return user_doc["name"]
+    return user_doc["displayName"]
 
 def generate_digital_twin_path(user_doc, digital_twin_doc):
-    user_name = user_doc["name"]
+    user_name = user_doc["displayName"]
     dt_name = digital_twin_doc["name"]
     dt_path = os.path.join(user_name, dt_name)
     return dt_path
 
 def generate_execution_path(user_doc, digital_twin_doc, execution_doc):
-    execution_name = execution_doc["name"]
+    execution_name = execution_doc["title"]
     dt_path = generate_digital_twin_path(user_doc, digital_twin_doc)
     execution_path = os.path.join(dt_path, execution_name)
     return execution_path

--- a/odtp/helpers/filesystem.py
+++ b/odtp/helpers/filesystem.py
@@ -25,16 +25,19 @@ def delete_folders(relative_paths, odtp_path = config.ODTP_PATH):
 
 
 def generate_user_path(user_doc):
-    return user_doc["displayName"]
+    abs_user_path = os.path.join(config.ODTP_PATH, user_doc["displayName"])
+    return 
 
 def generate_digital_twin_path(user_doc, digital_twin_doc):
     user_name = user_doc["displayName"]
     dt_name = digital_twin_doc["name"]
     dt_path = os.path.join(user_name, dt_name)
-    return dt_path
+    abs_dt_path = os.path.join(config.ODTP_PATH, dt_path)
+    return abs_dt_path
 
 def generate_execution_path(user_doc, digital_twin_doc, execution_doc):
     execution_name = execution_doc["title"]
     dt_path = generate_digital_twin_path(user_doc, digital_twin_doc)
     execution_path = os.path.join(dt_path, execution_name)
-    return execution_path
+    abs_execution_path = os.path.join(config.ODTP_PATH, execution_path)
+    return abs_execution_path

--- a/odtp/helpers/filesystem.py
+++ b/odtp/helpers/filesystem.py
@@ -1,0 +1,23 @@
+
+import logging
+import shutil
+import os
+import odtp.helpers.settings as config
+
+def create_main_folders(odtp_path = config.ODTP_PATH):
+    components_folder = os.path.join(odtp_path, 'components')
+    users_folder = os.path.join(odtp_path, 'users')
+
+    os.makedirs(components_folder, exist_ok=True)
+    os.makedirs(users_folder, exist_ok=True)
+
+    logging.info("Folders created: %s, %s", components_folder, users_folder)
+
+def deleted_main_folders(odtp_path = config.ODTP_PATH):
+    components_folder = os.path.join(odtp_path, 'components')
+    users_folder = os.path.join(odtp_path, 'users')
+
+    shutil.rmtree(components_folder)
+    shutil.rmtree(users_folder)
+
+    logging.info("Folders deleted: %s, %s", components_folder, users_folder)

--- a/odtp/helpers/filesystem.py
+++ b/odtp/helpers/filesystem.py
@@ -5,19 +5,15 @@ import os
 import odtp.helpers.settings as config
 
 def create_main_folders(odtp_path = config.ODTP_PATH):
-    components_folder = os.path.join(odtp_path, 'components')
     users_folder = os.path.join(odtp_path, 'users')
 
-    os.makedirs(components_folder, exist_ok=True)
     os.makedirs(users_folder, exist_ok=True)
 
-    logging.info("Folders created: %s, %s", components_folder, users_folder)
+    logging.info("Folders created: %s, %s", users_folder)
 
-def deleted_main_folders(odtp_path = config.ODTP_PATH):
-    components_folder = os.path.join(odtp_path, 'components')
+def delete_main_folders(odtp_path = config.ODTP_PATH):
     users_folder = os.path.join(odtp_path, 'users')
 
-    shutil.rmtree(components_folder)
     shutil.rmtree(users_folder)
 
-    logging.info("Folders deleted: %s, %s", components_folder, users_folder)
+    logging.info("Folders deleted: %s, %s", users_folder)

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -332,6 +332,7 @@ def add_digital_twin(userRef, name):
     with MongoClient(ODTP_MONGO_SERVER) as client:
         db = client[ODTP_MONGO_DB]
         digital_twin_data["userRef"] = userRef
+        print(digital_twin_data)
         digital_twin_id = (
             db[collection_digital_twins].insert_one(digital_twin_data).inserted_id
         )

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -314,7 +314,6 @@ def get_execution_path_docs(db, execution_id):
         collection=db.collection_digital_twins
         )
     user_id = dt_doc["userRef"]
-    print(user_id)
     user_doc = db.get_document_by_id(
         document_id=user_id, 
         collection=db.collection_users

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -282,6 +282,42 @@ def add_component_version(
             )
     return component_id, version_id
 
+def get_user_path_doc(db, user_id):
+    user_doc = db.get_document_by_id(
+        document_id=user_id, 
+        collection=db.collection_users
+        )
+    return user_doc
+
+def get_digital_twin_path_docs(db, dt_id):
+    dt_doc = db.get_document_by_id(
+        document_id=dt_id, 
+        collection=db.collection_digital_twins
+        )
+    user_id = dt_doc["userRef"]
+    user_doc = db.get_document_by_id(
+        document_id=user_id, 
+        collection=db.collection_users
+        )
+
+    return user_doc, dt_doc
+
+def get_execution_path_docs(db, execution_id):
+    execution_doc = db.get_document_by_id(
+        document_id=execution_id, 
+        collection=db.collection_executions
+        )
+    dt_id = execution_doc["digitalTwinRef"]
+    dt_doc = db.get_document_by_id(
+        document_id=dt_id, 
+        collection=db.collection_digital_twins
+        )
+    user_id = dt_doc["userRef"]
+    user_doc = db.get_document_by_id(
+        document_id=user_id, 
+        collection=db.collection_users
+        )
+    return user_doc, dt_doc, execution_doc
 
 def add_digital_twin(userRef, name):
     """add digital twin"""

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -308,7 +308,6 @@ def get_execution_path_docs(db, execution_id):
         collection=db.collection_executions
         )
     dt_id = execution_doc["digitalTwinRef"]
-    print(dt_id)
     dt_doc = db.get_document_by_id(
         document_id=dt_id, 
         collection=db.collection_digital_twins

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -308,11 +308,13 @@ def get_execution_path_docs(db, execution_id):
         collection=db.collection_executions
         )
     dt_id = execution_doc["digitalTwinRef"]
+    print(dt_id)
     dt_doc = db.get_document_by_id(
         document_id=dt_id, 
         collection=db.collection_digital_twins
         )
     user_id = dt_doc["userRef"]
+    print(user_id)
     user_doc = db.get_document_by_id(
         document_id=user_id, 
         collection=db.collection_users

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -332,7 +332,6 @@ def add_digital_twin(userRef, name):
     with MongoClient(ODTP_MONGO_SERVER) as client:
         db = client[ODTP_MONGO_DB]
         digital_twin_data["userRef"] = userRef
-        print(digital_twin_data)
         digital_twin_id = (
             db[collection_digital_twins].insert_one(digital_twin_data).inserted_id
         )

--- a/odtp/run.py
+++ b/odtp/run.py
@@ -217,11 +217,11 @@ class DockerManager:
         output, error = process.communicate()
 
         if process.returncode != 0:
-            log.exception(f"Failed to run Docker component {instance_name}: {error.decode()}")
+            log.exception(f"Failed to run Docker component {container_name}: {error.decode()}")
             return None
         else:
             docker_run_id = output.decode().strip()
-            log.info(f"Docker run was started with success: {instance_name}")
+            log.info(f"Docker run was started with success: {container_name}")
             return docker_run_id
 
     def stop_component(self, name="odtpruntest"):
@@ -245,7 +245,7 @@ class DockerManager:
         else:
             return f"Docker component {name} has been stopped."
 
-    def delete_component(self, instance_name="odtpruntest"):
+    def delete_component(self, container_name="odtpruntest"):
         """
         Delete a Docker component.
 
@@ -255,16 +255,16 @@ class DockerManager:
         Returns:
             str: A message indicating the Docker component has been deleted.
         """
-        log.info(f"Deleting Docker component {instance_name}")
-        docker_rm_command = ["docker", "rm", instance_name]
+        log.info(f"Deleting Docker component {container_name}")
+        docker_rm_command = ["docker", "rm", container_name]
         process = subprocess.Popen(docker_rm_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         _, error = process.communicate()
 
         if process.returncode != 0:
-            log.exception(f"Failed to delete Docker component {instance_name}: {error.decode()}")
+            log.exception(f"Failed to delete Docker component {container_name}: {error.decode()}")
             return None
         else:
-            return f"Docker component {instance_name} has been deleted."
+            return f"Docker component {container_name} has been deleted."
         
     def delete_image(self):
         """

--- a/poetry.lock
+++ b/poetry.lock
@@ -1526,6 +1526,23 @@ text-unidecode = ">=1.3"
 unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
+name = "python-slugify"
+version = "8.0.4"
+description = "A Python slugify application that also handles Unicode"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
+    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
+
+[[package]]
 name = "python-socketio"
 version = "5.11.3"
 description = "Socket.IO server and client for Python"
@@ -2153,4 +2170,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "aae5db2a78674fa5f3c6e3b65137ed51bd3945dc28af20e853475e09ea0f4582"
+content-hash = "01a8a1407af6833d2985be45427d07be2ba86b3ef344ee3f82214538c3ecde84"


### PR DESCRIPTION
Let's follow a folder structure that can be based on the organization of MongoDB. This goes as follows: 

```
components 
users
   - digital_twins
     - executions
       - steps
         - odtp-input
         - odtp-output
```

In this PR I implemented the setup of those two main folders. The project folder would be similar to the digital_twins folder. The rest of the folder structure remains as usual.  

