### PR TITLE
Delete s3 Objects and items related to an execution

### DIFF
--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -121,22 +121,6 @@ def streamlogs(
         sys.exit()
 
 
-
-@app.command()
-def output(
-    execution_id: str = typer.Option(
-        ..., "--execution-id", help="Specify the ID of the execution"
-    ),
-    project_path: str = typer.Option(
-        ..., "--project-path", help="Specify the path for the execution"
-    ),
-): 
-    try:
-        display_tree(project_path)
-    except Exception as e:
-        print(f"ERROR: Output printing failed: {e}")       
-        raise typer.Abort()
-
 @app.command()
 def delete(
     execution_name: str = typer.Option(
@@ -146,19 +130,18 @@ def delete(
         None, "--execution-id", help="Specify the ID of the execution"
     ),
     project_path: str = typer.Option(
-        None "--project-path", help="Specify the path for the execution"
+        None, "--project-path", help="Specify the path for the execution"
     ),
     keep_project_path: bool = typer.Option(
         True, "--keep-project-path", help="Keep the project directory after deleting contents"
     ),
-
 ):
     try:
         if execution_id is None and execution_name is None:
             raise typer.Exit("Please provide either --execution-name or --execution-id")
 
         if execution_name:
-            execution_id = db.get_document_id_by_field_value("title", execution_name, "executions")
+            execution_id = db.get_document_id_by_field_value("title", execution_name, db.collection_executions)
 
         # S3
         s3_keys = db.get_all_outputs_s3_keys(execution_id)

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -143,6 +143,9 @@ def output(
         s3M = s3Manager()
         s3M.deletePaths(s3_keys)
 
+        # DB
+        db.delete_execution(execution_id)
+
         # Folders
         odtp_env.delete_folder(project_path)
 

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -146,7 +146,7 @@ def delete(
         None, "--execution-id", help="Specify the ID of the execution"
     ),
     project_path: str = typer.Option(
-        ..., "--project-path", help="Specify the path for the execution"
+        None "--project-path", help="Specify the path for the execution"
     ),
     keep_project_path: bool = typer.Option(
         True, "--keep-project-path", help="Keep the project directory after deleting contents"

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -130,6 +130,28 @@ def output(
     project_path: str = typer.Option(
         ..., "--project-path", help="Specify the path for the execution"
     ),
+): 
+    try:
+        display_tree(project_path)
+    except Exception as e:
+        print(f"ERROR: Output printing failed: {e}")       
+        raise typer.Abort()
+
+@app.command()
+def delete(
+    execution_name: str = typer.Option(
+        None, "--execution-name", help="Specify the name of the execution"
+    ),
+    execution_id: str = typer.Option(
+        None, "--execution-id", help="Specify the ID of the execution"
+    ),
+    project_path: str = typer.Option(
+        ..., "--project-path", help="Specify the path for the execution"
+    ),
+    keep_project_path: bool = typer.Option(
+        True, "--keep-project-path", help="Keep the project directory after deleting contents"
+    ),
+
 ):
     try:
         if execution_id is None and execution_name is None:
@@ -147,7 +169,7 @@ def output(
         db.delete_execution(execution_id)
 
         # Folders
-        odtp_env.delete_folder(project_path)
+        odtp_env.delete_folder(project_path,keep_project_path=keep_project_path) 
 
     except Exception as e:
         log.error(f"ERROR: Delete execution failed: {e}")       

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -156,10 +156,14 @@ def delete(
             odtp_env.delete_folder(project_path, keep_project_path=keep_project_path) 
 
     except Exception as e:
-        log.error(f"ERROR: Delete execution failed: {e}")       
+        msg = f"ERROR: Delete execution failed: {e}"
+        log.exception(msg)
+        print(msg)       
         raise typer.Abort()  
     else:
-        log.info("SUCCESS: execution has been deleted")
+        msg = "SUCCESS: execution has been deleted"
+        log.info(msg)
+        print(msg)
 
 if __name__ == "__main__":
     app()

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -150,9 +150,10 @@ def delete(
 
         # DB
         db.delete_execution(execution_id)
-
+        
         # Folders
-        odtp_env.delete_folder(project_path,keep_project_path=keep_project_path) 
+        if project_path:
+            odtp_env.delete_folder(project_path, keep_project_path=keep_project_path) 
 
     except Exception as e:
         log.error(f"ERROR: Delete execution failed: {e}")       

--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -4,14 +4,20 @@ This scripts contains odtp subcommands for 'execution'
 import sys
 import typer
 from typing_extensions import Annotated
-import logging 
+import logging
 
 import odtp.mongodb.db as db
 import odtp.helpers.parse as odtp_parse
 from odtp.workflow import WorkflowManager
+from directory_tree import display_tree
+import odtp.helpers.environment as odtp_env
+from odtp.storage import s3Manager
+from nicegui import ui
 import os
 
 app = typer.Typer()
+
+log = logging.getLogger(__name__)
 
 log = logging.getLogger(__name__)
 
@@ -114,6 +120,37 @@ def streamlogs(
     except KeyboardInterrupt:
         sys.exit()
 
+
+
+@app.command()
+def output(
+    execution_id: str = typer.Option(
+        ..., "--execution-id", help="Specify the ID of the execution"
+    ),
+    project_path: str = typer.Option(
+        ..., "--project-path", help="Specify the path for the execution"
+    ),
+):
+    try:
+        if execution_id is None and execution_name is None:
+            raise typer.Exit("Please provide either --execution-name or --execution-id")
+
+        if execution_name:
+            execution_id = db.get_document_id_by_field_value("title", execution_name, "executions")
+
+        # S3
+        s3_keys = db.get_all_outputs_s3_keys(execution_id)
+        s3M = s3Manager()
+        s3M.deletePaths(s3_keys)
+
+        # Folders
+        odtp_env.delete_folder(project_path)
+
+    except Exception as e:
+        log.error(f"ERROR: Delete execution failed: {e}")       
+        raise typer.Abort()  
+    else:
+        log.info("SUCCESS: execution has been deleted")
 
 if __name__ == "__main__":
     app()

--- a/odtp/cli/new.py
+++ b/odtp/cli/new.py
@@ -78,7 +78,7 @@ def digital_twin_entry(
         raise typer.Exit("Please provide either --user-id or --user-email")
 
     if user_email:
-        user_id = db.get_document_id_by_field_value("user_email", user_email, "users")
+        user_id = db.get_document_id_by_field_value("email", user_email, "users")
 
     dt_id = db.add_digital_twin(userRef=user_id, name=name)
     log.info(f"Digital Twin added with ID {dt_id}")

--- a/odtp/helpers/environment.py
+++ b/odtp/helpers/environment.py
@@ -62,8 +62,11 @@ def directory_has_output(execution_id, project_folder):
             return True
     return False
 
-def delete_folder(folder_path):
+def delete_folder(folder_path, keep_project_path=True):
     if os.path.exists(folder_path):
         shutil.rmtree(folder_path)
+
+    if keep_project_path:
+        os.mkdir(folder_path)
 
     log.info("Folder deleted: %s", folder_path)

--- a/odtp/helpers/environment.py
+++ b/odtp/helpers/environment.py
@@ -1,9 +1,12 @@
 import os
+import shutil
+import logging
 
 import odtp.helpers.utils as utils
 import odtp.helpers.utils as odtp_utils
 import odtp.mongodb.db as db
 
+log = logging.getLogger(__name__)
 
 class OdtpLocalEnvironmentException(Exception):
     pass
@@ -58,3 +61,9 @@ def directory_has_output(execution_id, project_folder):
         if len(os.listdir(output_dir)) != 0:
             return True
     return False
+
+def delete_folder(folder_path):
+    if os.path.exists(folder_path):
+        shutil.rmtree(folder_path)
+
+    log.info("Folder deleted: %s", folder_path)

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -124,11 +124,11 @@ def check_document_id_in_collection(document_id, collection):
 
 
 def delete_document_by_id(document_id, collection):
-    log.info(f"Deleting {collection} : {document_id}")
+    log.debug(f"Deleting {collection} : {document_id}")
     with MongoClient(ODTP_MONGO_SERVER) as client:
         db = client[ODTP_MONGO_DB]
         document = db[collection].delete_one({"_id": ObjectId(document_id)})
-        log.info(f"Document with ID {document_id} was deleted")
+        log.debug(f"Document with ID {document_id} was deleted")
 
 
 def get_sub_collection_items(collection, sub_collection, item_id, ref_name, sort_by=None):

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -451,7 +451,7 @@ def delete_execution(execution_id):
     for step_id in steps_ids:
         logs_ids = get_documents_id_by_field_value("stepRef", str(step_id), collection_logs)
         if logs_ids:
-            _ = [delete_document_by_id(logs_id, collection_logs) for log_id in logs_ids]
+            _ = [delete_document_by_id(log_id, collection_logs) for log_id in logs_ids]
 
         output_ids = get_document_id_by_field_value("stepRef", str(step_id), collection_outputs)
         if output_ids:

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -124,6 +124,7 @@ def check_document_id_in_collection(document_id, collection):
 
 
 def delete_document_by_id(document_id, collection):
+    log.info(f"Deleting {collection} : {document_id}")
     with MongoClient(ODTP_MONGO_SERVER) as client:
         db = client[ODTP_MONGO_DB]
         document = db[collection].delete_one({"_id": ObjectId(document_id)})
@@ -439,13 +440,14 @@ def get_all_outputs_s3_keys(execution_id):
 
     return s3_keys
 
-def delete_execution(execution_id):
+def delete_execution(execution_id, debug=True):
     # DB
     # Delete execution, steps, output, logs, 
     # Update: remove id from results, remove execution from dt
     execution_doc = get_document_by_id(execution_id, collection_executions)
     digital_twin_id = execution_doc["digitalTwinRef"]
-    results_id = get_document_by_id(digital_twin_id, collection_digital_twins)["results"][0]
+    # TODO: Waiting for results to be implemented
+    #results_id = get_document_by_id(digital_twin_id, collection_digital_twins)["results"][0]
 
     steps_ids = execution_doc['steps']
     for step_id in steps_ids:
@@ -453,11 +455,13 @@ def delete_execution(execution_id):
         if logs_ids:
             _ = [delete_document_by_id(log_id, collection_logs) for log_id in logs_ids]
 
-        output_ids = get_document_id_by_field_value("stepRef", str(step_id), collection_outputs)
+        output_ids = get_documents_id_by_field_value("stepRef", str(step_id), collection_outputs)
         if output_ids:
             # Update the results document without any outputs reference
             for output_id in output_ids:
-                _ = remove_value_from_list_in_field(collection_results, results_id, "output", ObjectId(output_id))
+                # TODO: Waiting for results to be implemented
+                #_ = remove_value_from_list_in_field(collection_results, results_id, "output", ObjectId(output_id))
+                pass
             # Delete the output document
             _ = [delete_document_by_id(output_id, collection_outputs) for output_id in output_ids]
 

--- a/odtp/run.py
+++ b/odtp/run.py
@@ -221,7 +221,7 @@ class DockerManager:
         process = subprocess.Popen(command_string, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True)
 
         output, error = process.communicate()
-
+        
         if process.returncode != 0:
             log.exception(f"Failed to run Docker component {container_name}: {error.decode()}")
             return None

--- a/odtp/storage.py
+++ b/odtp/storage.py
@@ -138,7 +138,7 @@ class s3Manager:
                 for key in objects_to_delete['Contents']:
                     self.s3.delete_object(Bucket=self.bucketName, Key=key['Key'])
                     print(key['Key'])
-                logging.info(f"Path '{s3_path}' deleted from S3 bucket")
+                log.info(f"Path '{s3_path}' deleted from S3 bucket")
 
     def create_folders(self, structure):
         self.s3.createFolderStructure(structure)

--- a/odtp/storage.py
+++ b/odtp/storage.py
@@ -122,6 +122,24 @@ class s3Manager:
         self.s3.delete_object(Bucket=self.bucketName, Key=s3_path)
         log.info(f"File '{s3_path}' deleted from S3 bucket")
 
+    # Method to delete multiple files in s3 
+    def deletePaths(self, s3_paths):
+        """
+        Deletes multiple files from specific paths in the S3 bucket.
+        Args:
+            s3_paths (list): A list of S3 paths of the files to delete.
+        Returns:
+            None
+        """
+
+        for s3_path in s3_paths:
+            objects_to_delete = self.s3.list_objects(Bucket=self.bucketName, Prefix=s3_path)
+            if 'Contents' in objects_to_delete:
+                for key in objects_to_delete['Contents']:
+                    self.s3.delete_object(Bucket=self.bucketName, Key=key['Key'])
+                    print(key['Key'])
+                logging.info(f"Path '{s3_path}' deleted from S3 bucket")
+
     def create_folders(self, structure):
         self.s3.createFolderStructure(structure)
         log.info("Folder structure generated")

--- a/odtp/storage.py
+++ b/odtp/storage.py
@@ -137,7 +137,6 @@ class s3Manager:
             if 'Contents' in objects_to_delete:
                 for key in objects_to_delete['Contents']:
                     self.s3.delete_object(Bucket=self.bucketName, Key=key['Key'])
-                    print(key['Key'])
                 log.info(f"Path '{s3_path}' deleted from S3 bucket")
 
     def create_folders(self, structure):


### PR DESCRIPTION
These methods allows to delete all items related to an execution including s3 objects. It updates the digital twin document removing the reference to the execution document. 