### PR TITLE
chore(cli): cleanup execution commands that are only for the gui

### DIFF
--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -9,7 +9,6 @@ import logging
 import odtp.mongodb.db as db
 import odtp.helpers.parse as odtp_parse
 from odtp.workflow import WorkflowManager
-from directory_tree import display_tree
 import os
 
 app = typer.Typer()
@@ -91,25 +90,9 @@ def run(
     else:
         log.info("SUCCESS: containers for the execution have been run")      
 
-@app.command()
-def output(
-
-        execution_id: str = typer.Option(
-        ..., "--execution-id", help="Specify the ID of the execution"
-    ),
-    project_path: str = typer.Option(
-        ..., "--project-path", help="Specify the path for the execution"
-    ),
-): 
-    try:
-        display_tree(project_path)
-    except Exception as e:
-        print(f"ERROR: Output printing failed: {e}")       
-        raise typer.Abort()
-
 
 @app.command()
-def logs(
+def streamlogs(
     project_path: str = typer.Option(
         ..., "--project-path", help="Specify the path for the execution"
     ),

--- a/odtp/dashboard/page_run/run.py
+++ b/odtp/dashboard/page_run/run.py
@@ -74,7 +74,7 @@ def ui_run_execution(dialog, result, current_run, folder_status):
         cli_log_commands = []
         for i, _ in enumerate(execution["versions"]):
             cli_log_commands. append(rh.build_cli_command(
-                cmd="logs",
+                cmd="streamlogs",
                 project_path=project_path,
                 step_nr=str(i)
             ))


### PR DESCRIPTION
Cleanup commands that are only used from the gui:
- rename command to stream logs
- command to show project folder is now longer needed in the changed workflow for execution runs.