### PR TITLE
feat(run): Added access to gpus by default

### DIFF
--- a/odtp/run.py
+++ b/odtp/run.py
@@ -205,6 +205,7 @@ class DockerManager:
 
         docker_run_command = ["docker", "run", "--rm", "-it", "--name", container_name,
                               "--network", "odtp_odtp-network",
+                              "--gpus", "all",
                               "--volume", f"{os.path.abspath(self.input_volume)}:/odtp/odtp-input",
                               "--volume", f"{os.path.abspath(self.log_volume)}:/odtp/odtp-logs",
                               "--volume", f"{os.path.abspath(self.output_volume)}:/odtp/odtp-output"] + env_args + ports_args + secrets_args + [self.docker_image_name]


### PR DESCRIPTION
Added access to gpus when running docker. This allows the components related to the causal intervention case to be run. 

In the future, we can add this flag as optional depending on the user configuration or the `odtp.yml` requirements. 