### PR TITLE
feat(dockerhub): Compatibility with dockerhub images in CLI

### DIFF
--- a/odtp/cli/component.py
+++ b/odtp/cli/component.py
@@ -26,6 +26,9 @@ def prepare(
     image_name: str = typer.Option(
         ..., "--image_name", help="Specify the name of the component image"
     ),
+    image_link: str = typer.Option(
+        None, "--image_link", help="Specify the name of the component image link"
+    ),
     repository: str = typer.Option(
         ..., "--repository", help="Specify the git repository url"
     ),
@@ -33,7 +36,8 @@ def prepare(
     try:
         componentManager = DockerManager(
             repo_url=repository, 
-            image_name=image_name, 
+            image_name=image_name,
+            image_link=image_link,
             project_folder=folder
         )
         componentManager.prepare_component()

--- a/odtp/cli/new.py
+++ b/odtp/cli/new.py
@@ -46,6 +46,9 @@ def odtp_component_entry(
     ports: Annotated[str, typer.Option(
         help="Specify ports seperated by a comma i.e. 8501,8201"
     )] = None,
+    image_link: Annotated[str, typer.Option(
+        help="Specify the DockerHub image link"
+    )] = None,
 ):
     try:
         ports = odtp_parse.parse_component_ports(ports)
@@ -55,6 +58,7 @@ def odtp_component_entry(
                 component_name=name,
                 repo_info=repo_info,
                 component_version=component_version,
+                image_link=image_link,
                 type=type,
                 ports=ports,
             )

--- a/odtp/helpers/utils.py
+++ b/odtp/helpers/utils.py
@@ -26,6 +26,9 @@ def get_execution_step_name(component_name, component_version, step_index=None):
         return f"{component_name}_{component_version}"
     return f"{step_index}_{component_name}_{component_version}"
 
+def get_execution_step_image_name(component_name, component_version):
+    return f"{component_name}:{component_version}"
+
 
 def get_version_name_dict_for_version_ids(version_ids, naming_function=get_execution_step_name):
     versions = db.get_document_by_ids_in_collection(

--- a/odtp/mongodb/db.py
+++ b/odtp/mongodb/db.py
@@ -208,6 +208,7 @@ def add_component_version(
     repo_info,
     component_name,
     component_version,
+    image_link,
     type,
     ports,
 ):
@@ -226,7 +227,7 @@ def add_component_version(
         version_commit = [version["commit"] for version in tagged_versions
                           if version["name"] == component_version]
         if not version_commit:
-            raise Exception("Version does not exist in repo")
+            log.warning("Version does not exist in repo and it will only be valid if the image is already built")
     except Exception as e:
         e.add_note("-> Component Version not valid: was not stored in mongodb")
         raise (e)
@@ -282,7 +283,7 @@ def add_component_version(
                 "odtp_version": odtp_utils.get_odtp_version(),
                 "component_version": component_version,
                 "commitHash": commit_hash,
-                "dockerHubLink": "",
+                "imageLink": image_link,
                 "parameters": {},
                 "title": "Title for Version v1.0",
                 "description": "Description for Version v1.0",

--- a/odtp/run.py
+++ b/odtp/run.py
@@ -26,14 +26,17 @@ class OdtpRunSetupException(Exception):
 
 
 class DockerManager:
-    def __init__(self, repo_url="", commit_hash="", image_name="", project_folder=""):
+    def __init__(self, repo_url="", commit_hash="", image_name="", project_folder="", image_link=None):
         log.debug(f"""Docker manager initialized with repo_url: {repo_url},
-                     commit_hash: {commit_hash}, project_folder: {project_folder}, image_name: {image_name}""")
+                     commit_hash: {commit_hash}, 
+                     project_folder: {project_folder}, 
+                     image_name: {image_name}""")
         self.repo_url = repo_url
         self.commit_hash = commit_hash
         self.project_folder = project_folder
         self.repository_path = os.path.join(self.project_folder, REPO_DIR)
         self.dockerfile_path = os.path.join(self.project_folder, REPO_DIR)
+        self.docker_image_link = image_link
         self.docker_image_name = image_name
         self.input_volume = os.path.join(self.project_folder, INPUT_DIR)
         self.log_volume = os.path.join(self.project_folder, LOG_DIR)
@@ -43,8 +46,11 @@ class DockerManager:
         self._checks_for_prepare()
         self._create_project_folder_structure()
         if not self._check_if_image_exists():
-            self._download_repo()
-            self._build_image()   
+            if not self.docker_image_link:
+                self._download_repo()
+                self._build_image()
+            else:
+                self._pull_image()  
 
     def _create_project_folder_structure(self):
         """Create all the folder structure in project_folder""" 
@@ -150,6 +156,18 @@ class DockerManager:
         log.info(f"RUN: Building Docker image {self.docker_image_name} from {self.dockerfile_path}")
         subprocess.check_output(["docker", "build", "-t", self.docker_image_name, self.dockerfile_path])
 
+    def _pull_image(self):
+        """
+        Pull a Docker image from a Docker registry.
+    
+        Args:
+            image_name (str): The name of the Docker image to pull.
+        """
+        log.info(f"RUN: Pulling Docker image {self.docker_image_name}")
+        subprocess.check_output(["docker", "pull", self.docker_image_link])
+        subprocess.check_output(["docker", "tag", self.docker_image_link, self.docker_image_name])
+        subprocess.check_output(["docker", "rmi", self.docker_image_link])
+
     def _check_image_exists(self):
         """
         Check whether a docker image exists
@@ -181,15 +199,15 @@ class DockerManager:
         Returns:
             str: The ID of the Docker run.
         """
-        log.info(f"RUN: Running Docker component {self.repo_url} in docker with name {self.docker_image_name}")
+        log.info(f"RUN: Running ODTP component. Repo: {self.repo_url}, Image name: {self.docker_image_name}, Container Name: {container_name}")
         
         if step_id:
             parameters["ODTP_STEP_ID"] = step_id
-            parameters["ODTP_MONGO_SERVER"] = config.ODTP_MONGO_SERVER
-            parameters["ODTP_S3_SERVER"] = config.ODTP_S3_SERVER
-            parameters["ODTP_BUCKET_NAME"] = config.ODTP_BUCKET_NAME
-            parameters["ODTP_ACCESS_KEY"] = config.ODTP_ACCESS_KEY
-            parameters["ODTP_SECRET_KEY"] = config.ODTP_SECRET_KEY
+        parameters["ODTP_MONGO_SERVER"] = config.ODTP_MONGO_SERVER
+        parameters["ODTP_S3_SERVER"] = config.ODTP_S3_SERVER
+        parameters["ODTP_BUCKET_NAME"] = config.ODTP_BUCKET_NAME
+        parameters["ODTP_ACCESS_KEY"] = config.ODTP_ACCESS_KEY
+        parameters["ODTP_SECRET_KEY"] = config.ODTP_SECRET_KEY
 
         env_args = [f"-e \"{key}={value}\"" for key, value in parameters.items() if key]
 

--- a/odtp/workflow.py
+++ b/odtp/workflow.py
@@ -19,7 +19,8 @@ class WorkflowManager:
         self.execution = execution_data
         self.schema = execution_data["workflowSchema"]
         self.working_path = working_path
-        self.image_names = []
+        self.docker_image_names = []
+        self.docker_image_links = []
         self.repo_urls = []
         self.commits = []
         self.container_names = []
@@ -38,6 +39,7 @@ class WorkflowManager:
                 component_name = version_doc["component"]["componentName"]
                 component_version = version_doc["component_version"]
                 repo_link = version_doc["component"]["repoLink"]
+                image_link = version_doc["imageLink"]
                 commit_hash = version_doc["commitHash"]
 
                 step_name = odtp_utils.get_execution_step_name(
@@ -50,12 +52,13 @@ class WorkflowManager:
                 step_folder_path = os.path.join(self.working_path, step_name)
                 self.steps_folder_paths.append(step_folder_path)
 
-                image_name = odtp_utils.get_execution_step_name(
+                image_name = odtp_utils.get_execution_step_image_name(
                     component_name=component_name, 
                     component_version=component_version
                 )
 
-                self.image_names.append(image_name)
+                self.docker_image_names.append(image_name)
+                self.docker_image_links.append(image_link)
                 self.repo_urls.append(repo_link)
                 self.commits.append(commit_hash)
                 self.container_names.append(step_name)
@@ -89,7 +92,8 @@ class WorkflowManager:
             componentManager = DockerManager(
                 repo_url=self.repo_urls[step_index],
                 commit_hash=self.commits[step_index],
-                image_name=self.image_names[step_index],
+                image_name=self.docker_image_names[step_index],
+                image_link=self.docker_image_links[step_index],
                 project_folder=self.steps_folder_paths[step_index]
             )
 
@@ -157,13 +161,13 @@ class WorkflowManager:
             # By now the image_name is just the name of the component and the version
             componentManager = DockerManager(
                 repo_url=self.repo_urls[step_index], 
-                image_name=self.image_names[step_index],
+                image_name=self.docker_image_names[step_index],
                 project_folder=self.steps_folder_paths[step_index]
             )
             
             # instance_name = "{}_{}".format(component_doc["componentName"], version_doc["version"])
             #log.info(env_files[step_index])
-            log.info(f"run docker image {self.image_names[step_index]} at path {self.steps_folder_paths[step_index]}")
+            log.info(f"run docker image {self.docker_image_names[step_index]} at path {self.steps_folder_paths[step_index]}")
             componentManager.run_component(
                 parameters,
                 secrets,


### PR DESCRIPTION
Here, I added the option to use prebuilt images from dockerhub, or github images registry. 

The CLI can be tested with: 

Prepare components command:
``` bash
odtp component prepare \
--folder /c/Users/Carlos/pro/odtp_dts/odtp_v1/test \
--image_name odtp-component-example \
--repository https://github.com/odtp-org/odtp-component-example \
--image_link caviri/odtp-component-example:v0.1.6
```

Adding components. 
``` bash
odtp new odtp-component-entry \
--name odtp-component-example \
--component-version v0.1.1 \
--repository https://github.com/odtp-org/odtp-sql-dataloader \
--image-link caviri/odtp-component-example
```

Additionally, the digital twins' executions can be tested easily by using a `docker-compose.yml` that runs the different steps https://github.com/odtp-org/dt-mobility-causal-intervention/blob/main/docker-compose.yml 