### PR TITLE
fix(workflow.py): imageLink is an optional value on execution

### DIFF
--- a/odtp/workflow.py
+++ b/odtp/workflow.py
@@ -39,7 +39,7 @@ class WorkflowManager:
                 component_name = version_doc["component"]["componentName"]
                 component_version = version_doc["component_version"]
                 repo_link = version_doc["component"]["repoLink"]
-                image_link = version_doc["imageLink"]
+                image_link = version_doc.get("imageLink")
                 commit_hash = version_doc["commitHash"]
 
                 step_name = odtp_utils.get_execution_step_name(


### PR DESCRIPTION
This PR fixes a bug in the workflow execution: the imageLink is optional and not always there.