### PR TITLE
Feat/gui secrets for execution run

### DIFF
--- a/odtp/cli/execution.py
+++ b/odtp/cli/execution.py
@@ -45,9 +45,7 @@ def prepare(
             document_id=execution_id,
             collection=db.collection_executions
         )
-        step_count = len(execution["workflowSchema"]["workflowExecutorSchema"])
-        secrets = [None for i in range(step_count)]
-        flowManager = WorkflowManager(execution, project_path, secrets)
+        flowManager = WorkflowManager(execution, project_path)
         flowManager.prepare_workflow()
     except Exception as e:
         msg = f"ERROR: Prepare execution failed: {e}"

--- a/odtp/dashboard/page_executions/table.py
+++ b/odtp/dashboard/page_executions/table.py
@@ -167,8 +167,9 @@ class ExecutionTable:
             f"The selected {len(self.selected_execution_ids)} component versions have been deprecated.",
             type="positive"
         )
-        from odtp.dashboard.page_executions.main import ui_executions_table
+        from odtp.dashboard.page_executions.main import ui_executions_table, ui_execution_select
         ui_executions_table.refresh()
+        ui_execution_select.refresh()
 
     def activate_selected(self):
         """activate selected executions"""
@@ -177,5 +178,6 @@ class ExecutionTable:
             f"The selected {len(self.selected_execution_ids)} component versions have been activated.",
             type="positive"
         )
-        from odtp.dashboard.page_executions.main import ui_executions_table
+        from odtp.dashboard.page_executions.main import ui_executions_table, ui_execution_select
         ui_executions_table.refresh()
+        ui_execution_select.refresh()

--- a/odtp/dashboard/page_users/workarea.py
+++ b/odtp/dashboard/page_users/workarea.py
@@ -3,7 +3,7 @@ from nicegui import ui, events
 import odtp.dashboard.utils.ui_theme as ui_theme
 import odtp.helpers.secrets as secrets
 import odtp.dashboard.page_users.storage as storage
-from odtp.helpers.settings import ODTP_PASSWORD
+from odtp.helpers.settings import ODTP_PASSWORD, ODTP_SECRETS_FILE
 
 
 class Workarea():
@@ -39,16 +39,11 @@ class Workarea():
                 on_upload=self.handle_upload,
                 label="upload secrets (store encrypted)"
             ).classes('max-w-full')
-            ui.button(
-                "get secrets",
-                on_click=self.decrypt_secrets,
-                icon="link",
-            )
 
     async def handle_upload(self, event):
         """Handle file upload and encrypt the file."""
         content = event.content.read().decode('utf-8')
-        file_path = os.path.join(self.current_user["workdir"], f"odtp-secrets.txt")
+        file_path = os.path.join(self.current_user["workdir"], ODTP_SECRETS_FILE)
 
         salt, iv, encrypted_data = secrets.encrypt_text(content, ODTP_PASSWORD)
         # Save the encrypted data to a file

--- a/odtp/helpers/secrets.py
+++ b/odtp/helpers/secrets.py
@@ -3,6 +3,8 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.backends import default_backend
+from io import StringIO
+from dotenv import dotenv_values
 
 # Constants
 SALT_SIZE = 16  # Salt size in bytes
@@ -36,8 +38,8 @@ def encrypt_text(text, password):
 
     return salt, iv, encrypted_data
 
-def decrypt_file(encrypted_file_path, password):
-    """Decrypt an encrypted file and return the decrypted content."""
+def decrypt_file_to_dict(encrypted_file_path, password):
+    """Decrypt an encrypted file and return its content as a dictionary."""
     with open(encrypted_file_path, "rb") as f:
         file_data = f.read()
 
@@ -65,5 +67,8 @@ def decrypt_file(encrypted_file_path, password):
     pad_length = decrypted_padded_data[-1]  # Last byte indicates padding length
     decrypted_data = decrypted_padded_data[:-pad_length]
 
-    # Return the decrypted content as a string
-    return decrypted_data.decode('utf-8')
+    # Parse the decrypted content as a dotenv dictionary
+    decrypted_str = decrypted_data.decode('utf-8')
+    secrets_dict = dotenv_values(stream=StringIO(decrypted_str))
+
+    return dict(secrets_dict)

--- a/odtp/helpers/settings.py
+++ b/odtp/helpers/settings.py
@@ -24,6 +24,8 @@ ODTP_SECRET_KEY = os.getenv("ODTP_SECRET_KEY")
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN")
 ODTP_PASSWORD = os.getenv("ODTP_PASSWORD")
+ODTP_SECRETS_FILE = "odtp-secrets.txt"
+ODTP_LOG_PATH = "odtp-logs/log.txt"
 
 ODTP_DASHBOARD_PORT = int(os.getenv("ODTP_DASHBOARD_PORT"))
 ALLOW_DOCKER_GPUS = os.getenv("ALLOW_DOCKER_GPUS")

--- a/odtp/run.py
+++ b/odtp/run.py
@@ -220,7 +220,6 @@ class DockerManager:
             ports_args = [f"-p {port_pair}" for port_pair in ports]
         else:
             ports_args = [""]
-
         if secrets:
             secrets_args = [f"-e \"{key}={value}\"" for key, value in secrets.items()]
         else:
@@ -247,7 +246,7 @@ class DockerManager:
         output, error = process.communicate()
 
         if process.returncode != 0:
-            msg = f"Failed to run Docker component {container_name}: {error.decode()}"
+            msg = f"Failed to run Docker component\n{container_name}:\n{error.decode()}"
             if step_id:
                 db.update_step(step_id, {"error":True, "msg": msg})
             log.exception(msg)

--- a/odtp/workflow.py
+++ b/odtp/workflow.py
@@ -1,6 +1,9 @@
 import os
+import json
 from odtp.run import DockerManager, OdtpRunSetupException
 import odtp.helpers.utils as odtp_utils
+import odtp.helpers.parse as odtp_parse
+import odtp.helpers.secrets as odtp_secrets
 import odtp.helpers.settings as config
 import odtp.helpers.environment as env_helpers
 import odtp.mongodb.db as db
@@ -13,7 +16,7 @@ log.addHandler(config.get_command_log_handler())
 
 
 class WorkflowManager:
-    def __init__(self, execution_data, working_path, secrets):
+    def __init__(self, execution_data, working_path, secrets=None):
         # This workflow will have one execution ID associated
         # This class should contain flags used to know the status of the workflow.
         self.execution = execution_data
@@ -25,7 +28,8 @@ class WorkflowManager:
         self.commits = []
         self.container_names = []
         self.steps_folder_paths = []
-        self.secrets = secrets
+        if secrets:
+            self.secrets = secrets
 
         for step_index in self.schema["workflowExecutorSchema"]:
             try:
@@ -124,7 +128,12 @@ class WorkflowManager:
             )
             secrets = self.secrets[step_index]
             if not secrets and step_doc.get("secrets"):
-                secrets = step_doc["secrets"]
+                secrets_file = step_doc["secrets"]
+                decrypted_content = odtp_secrets.decrypt_file_to_dict(
+                    secrets_file,
+                    config.ODTP_PASSWORD
+                )
+                secrets = decrypted_content
 
             if not step_doc.get("run_step"):
                 log.info(f"step {step_index} was excluded from run")

--- a/odtp/workflow.py
+++ b/odtp/workflow.py
@@ -118,12 +118,13 @@ class WorkflowManager:
 
             step_id = self.execution["steps"][step_index]
 
-            secrets = self.secrets[step_index]
-
             step_doc = db.get_document_by_id(
                 document_id=step_id,
                 collection=db.collection_steps
             )
+            secrets = self.secrets[step_index]
+            if not secrets and step_doc.get("secrets"):
+                secrets = step_doc["secrets"]
 
             if not step_doc.get("run_step"):
                 log.info(f"step {step_index} was excluded from run")


### PR DESCRIPTION
This PR adds secrets handling for steps to the gui. 

* The step gets from the odtp.yml whether it needs secrets as `secrets:True` or `secrets:False`
* In the gui the user can upload a file with secrets and it gets stored encrypted in his user directory
* In the gui when the execution is selected for a run: if `secrets:True` for a step, the secrets in the step are updated to be the path to the users encrypted secret file
* On run of the execution the encrypted secrets file is decrypted if it exist in the step and added to the call to run the step at `workflow.py`

As a cleanup of the CLI, secrets are removed from the `prepare step`