### PR TITLE
fix: add new env variables ODTP_PASSWORD on env dist

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -16,6 +16,12 @@
 GITHUB_TOKEN=
 
 # ===========================================================
+# Credentials for odtp: to decrypt secret files
+# ===========================================================
+
+ODTP_PASSWORD=
+
+# ===========================================================
 # Credentials that you can choose on setup
 # - needed for all setup methods
 # ===========================================================


### PR DESCRIPTION
Update `.env.dist` to include `ODTP_PASSWORD`